### PR TITLE
Fix memory leak relating to audio buffer allocation

### DIFF
--- a/xclock.c
+++ b/xclock.c
@@ -830,11 +830,10 @@ static void *TempoTrackerThread() {
 
   aubio_tempo_t *tempo = new_aubio_tempo("default", BUFSIZE, HOPSIZE, SAMPLERATE);
   fvec_t *tempo_out = new_fvec(2);
+  fvec_t *aubio_buf = new_fvec(BUFSIZE);
+  
   for (;;) {
-    float buf[BUFSIZE];
-    pa_simple_read(s, buf, sizeof(buf), &error);
-    fvec_t *aubio_buf = new_fvec(BUFSIZE);
-    aubio_buf->data = buf;
+    pa_simple_read(s, aubio_buf->data, sizeof(float) * BUFSIZE, &error);
     aubio_tempo_do(tempo, aubio_buf, tempo_out);
     float confidence = aubio_tempo_get_confidence(tempo);
     Boolean is_beat = tempo_out->data[0] != 0.0;


### PR DESCRIPTION
TempoTrackerThread kept continuously allocating a buffer and completely ignoring it, which would cause memory usage to climb rapidly. Now, it only allocates the buffer once (when the thread starts) and makes proper use of it.

Solves issue #4.